### PR TITLE
Prevent reboot dorssel.usbipd-win version 2.3.0

### DIFF
--- a/manifests/d/dorssel/usbipd-win/2.3.0/dorssel.usbipd-win.installer.yaml
+++ b/manifests/d/dorssel/usbipd-win/2.3.0/dorssel.usbipd-win.installer.yaml
@@ -6,6 +6,9 @@ PackageVersion: 2.3.0
 MinimumOSVersion: 10.0.0.0
 InstallerType: wix
 Scope: machine
+InstallerSwitches:
+  Silent: /quiet /norestart
+  SilentWithProgress: /passive /norestart
 UpgradeBehavior: install
 ReleaseDate: 2022-04-27
 Installers:


### PR DESCRIPTION
Note: we do not accept return code 3010 as success (some other packages do...). This would completely suppress the feedback to the user that a restart is indeed required to complete installation.

Related: https://github.com/microsoft/winget-cli/issues/229
Fixes: https://github.com/dorssel/usbipd-win/issues/365

- [X] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [X] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md#validation) your manifest locally with `winget validate --manifest <path>`? 
- [X] Have you tested your manifest locally with `winget install --manifest <path>`?
- [X] Does your manifest conform to the [1.1 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.1.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

-----
